### PR TITLE
Check for response data before trying to access it

### DIFF
--- a/lib/Kazoo/Api/Data/Entity/PhoneNumber.php
+++ b/lib/Kazoo/Api/Data/Entity/PhoneNumber.php
@@ -35,7 +35,7 @@ class PhoneNumber extends AbstractEntity {
                     }
                     $result = $this->_client->put($uri, $this->getData());
                 }
-                $this->updateFromResult($result->data);
+                if (isset($result->data)) $this->updateFromResult($result->data);
                 break;
             case 'activate':
                 $result = $this->_client->put($uri . '/activate', $this->getData());


### PR DESCRIPTION
When updating phone number, if the response did not contain the data object it would throw an error
