### PR TITLE
1.1 cdrs

### DIFF
--- a/lib/Kazoo/Api/AbstractResource.php
+++ b/lib/Kazoo/Api/AbstractResource.php
@@ -142,7 +142,7 @@ abstract class AbstractResource {
         }
     }
 
-    private function process_response($response) {
+    protected function process_response($response) {
         $results = $response->data;
         if (is_object($results)
           && property_exists($results, "numbers")) {

--- a/lib/Kazoo/Api/Resource/Cdrs.php
+++ b/lib/Kazoo/Api/Resource/Cdrs.php
@@ -55,11 +55,13 @@ class Cdrs extends AbstractResource {
                                 $raw_entity_list = $this->process_response($response);
 
                                 $entity_list = array();
-                                foreach($raw_entity_list as $raw_entity){
-                                    $entity_class = static::$_entity_class;
-                                    $entityInstance = new $entity_class($this->_client, $this->_uri . "/" . $raw_entity->id);
-                                    $entityInstance->updateFromResult($raw_entity);
-                                    $entity_list[] = $entityInstance;
+                                if (!empty($raw_entity_list)) {
+                                    foreach($raw_entity_list as $raw_entity){
+                                        $entity_class = static::$_entity_class;
+                                        $entityInstance = new $entity_class($this->_client, $this->_uri . "/" . $raw_entity->id);
+                                        $entityInstance->updateFromResult($raw_entity);
+                                        $entity_list[] = $entityInstance;
+                                    }
                                 }
 
                                 return new $collection_type($entity_list);


### PR DESCRIPTION
Was throwing a too many requests error because the sdk was pulling the list of cdrs and then looping over them to then make a another call for each cdr to get all the data. Changed it so that it was marked as hydrated so it did not make the additional calls to the api.
