### PR TITLE
Populate keys if required is true, not just present.

### DIFF
--- a/lib/Kazoo/Api/JsonSchemaObjectFactory.php
+++ b/lib/Kazoo/Api/JsonSchemaObjectFactory.php
@@ -40,7 +40,7 @@ class JsonSchemaObjectFactory {
                                 }
                             } else {
                                 if (property_exists($property_meta, 'minLength') || property_exists($property_meta, 'maxLength')) {
-                                    if (property_exists($property_meta, 'required')){
+                                    if (property_exists($property_meta, 'required' && $property_meta->required)){
                                         $accumulator->$property_name = "";
                                     }
                                 } else {


### PR DESCRIPTION
Currently, string values default to "" when the 'required' key is present, even if it is false. This will result in an incorrect set of default values (for example, if a non-required string field has a minimum length, it will default to "", which is invalid).