### PR TITLE
Save auth token in session after creation

### DIFF
--- a/lib/Kazoo/AuthToken/User.php
+++ b/lib/Kazoo/AuthToken/User.php
@@ -173,6 +173,7 @@ class User implements AuthTokenInterface {
         switch ($response->status) {
         case "success":
             $this->auth_response = $response->data;
+            $_SESSION['Kazoo']['AuthToken']['User'] = $this->auth_response;
             $this->auth_response->auth_token = $response->auth_token;
             break;
         default:


### PR DESCRIPTION
Under certain circumstances the token was not being sent to the session, therefore on subsequent api calls a new token was being created, and if enough calls were made all tokens would be used.

I have now setup the token to be saved to session upon creation, so it is always available.