### PR TITLE
Add function to get the logged in userId

### DIFF
--- a/lib/hz2600/Kazoo/AuthToken/User.php
+++ b/lib/hz2600/Kazoo/AuthToken/User.php
@@ -102,6 +102,18 @@ class User implements AuthTokenInterface
      *
      * @return string
      */
+    public function getLoggedInUserId() {
+        $response = $this->getAuthResponse();
+        if (isset($response->owner_id)) {
+            return $response->owner_id;
+        }
+        return "";
+    }
+
+    /**
+     *
+     * @return string
+     */
     public function getToken() {
         $response = $this->getAuthResponse();
         if (isset($response->auth_token)) {


### PR DESCRIPTION
So we don't have to do another API call to get it (it is returned on AuthToken/User authentication). Useful for implementing voicemail access, etc. where the user will be logging in as themselves.