### PR TITLE
Allow auto answer to be set on quickcall

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Device.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Device.php
@@ -7,7 +7,7 @@ class Device extends AbstractEntity
     public function quickcall($number, $auto_answer = true) {
         $this->setTokenValue($this->getEntityIdName(), $this->getId());
         $this->setTokenValue('quickcall_number', $number);
-        $this->setTokenValue('auto_answer', ($auto_answer === 'true'));
+        $this->setTokenValue('auto_answer', $auto_answer ? 'true' : 'false');
         $this->get(array(), '/quickcall/{quickcall_number}?auto_answer={auto_answer}');
     }
 }

--- a/lib/hz2600/Kazoo/Api/Entity/Device.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Device.php
@@ -4,10 +4,14 @@ namespace Kazoo\Api\Entity;
 
 class Device extends AbstractEntity
 {
-    public function quickcall($number, $auto_answer = true) {
+    public function quickcall($number, $parameters = array()) {
         $this->setTokenValue($this->getEntityIdName(), $this->getId());
         $this->setTokenValue('quickcall_number', $number);
-        $this->setTokenValue('auto_answer', $auto_answer ? 'true' : 'false');
-        $this->get(array(), '/quickcall/{quickcall_number}?auto_answer={auto_answer}');
+        $query_string = '';
+        if (!empty($parameters)) {
+            $query_string = '?' . http_build_query($parameters);
+        }
+        $this->setTokenValue('query_string', $query_string);
+        $this->get(array(), '/quickcall/{quickcall_number}' . $query_string);
     }
 }

--- a/lib/hz2600/Kazoo/Api/Entity/Device.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Device.php
@@ -4,9 +4,10 @@ namespace Kazoo\Api\Entity;
 
 class Device extends AbstractEntity
 {
-    public function quickcall($number) {
+    public function quickcall($number, $auto_answer = true) {
         $this->setTokenValue($this->getEntityIdName(), $this->getId());
         $this->setTokenValue('quickcall_number', $number);
-        $this->get(array(), '/quickcall/{quickcall_number}');
+        $this->setTokenValue('auto_answer', ($auto_answer === 'true'));
+        $this->get(array(), '/quickcall/{quickcall_number}?auto_answer={auto_answer}');
     }
 }

--- a/lib/hz2600/Kazoo/Api/Entity/Device.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Device.php
@@ -11,7 +11,6 @@ class Device extends AbstractEntity
         if (!empty($parameters)) {
             $query_string = '?' . http_build_query($parameters);
         }
-        $this->setTokenValue('query_string', $query_string);
         $this->get(array(), '/quickcall/{quickcall_number}' . $query_string);
     }
 }


### PR DESCRIPTION
This enables functionality discussed here;
https://2600hz.atlassian.net/browse/KAZOO-719

and patched here: https://github.com/2600hz/kazoo/commit/78082c0637421b8032432f5ae117257b92b87e9f

Defaults to true which was how this worked before.

If you want a different approach taken for this (ie. allowing any arguments to be passed in--if so do we validate those?), let me know.