### PR TITLE
Add PATH Method to KazooSDK

### DIFF
--- a/lib/hz2600/Kazoo/Api/AbstractResource.php
+++ b/lib/hz2600/Kazoo/Api/AbstractResource.php
@@ -152,4 +152,14 @@ abstract class AbstractResource implements ChainableInterface
         $uri = $this->getUri($append_uri);
         return $this->getSDK()->delete($uri, $payload);
     }
+
+    /**
+     *
+     *
+     */
+    protected function patch($payload, $append_uri = null) {
+        $uri = $this->getUri($append_uri);
+        return $this->getSDK()->patch($uri, $payload);
+    }
+
 }

--- a/lib/hz2600/Kazoo/Api/Collection/Blacklists.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Blacklists.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Blacklists extends AbstractCollection
+{
+}
+

--- a/lib/hz2600/Kazoo/Api/Collection/Clicktocalls.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Clicktocalls.php
@@ -1,0 +1,14 @@
+<?php
+namespace Kazoo\Api\Collection;
+
+class Clicktocalls extends AbstractCollection
+{
+    /**
+     *
+     *
+     */
+    protected function getUriSnippet() {
+        return '/clicktocall';
+    }
+
+}

--- a/lib/hz2600/Kazoo/Api/Collection/Configs.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Configs.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Configs extends AbstractCollection
+{
+}
+

--- a/lib/hz2600/Kazoo/Api/Collection/Directories.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Directories.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Directories extends AbstractCollection
+{
+}
+

--- a/lib/hz2600/Kazoo/Api/Collection/Faxes.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Faxes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Faxes extends AbstractCollection
+{
+    protected function getUriSnippet() {
+        return "/faxes/outgoing";
+    }
+}

--- a/lib/hz2600/Kazoo/Api/Collection/Groups.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Groups.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Groups extends AbstractCollection
+{
+}
+

--- a/lib/hz2600/Kazoo/Api/Collection/Queues.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Queues.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Queues extends AbstractCollection
+{
+}
+
+

--- a/lib/hz2600/Kazoo/Api/Collection/Rates.php
+++ b/lib/hz2600/Kazoo/Api/Collection/Rates.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class Rates extends AbstractCollection
+{
+}
+

--- a/lib/hz2600/Kazoo/Api/Collection/ResourceTemplates.php
+++ b/lib/hz2600/Kazoo/Api/Collection/ResourceTemplates.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class ResourceTemplates extends AbstractCollection
+{
+    /**
+     *
+     *
+     */
+    protected function getUriSnippet() {
+        return '/resources/resource_templates';
+    }
+
+}

--- a/lib/hz2600/Kazoo/Api/Collection/TemporalRules.php
+++ b/lib/hz2600/Kazoo/Api/Collection/TemporalRules.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class TemporalRules extends AbstractCollection
+{
+}
+
+

--- a/lib/hz2600/Kazoo/Api/Collection/TemporalRulesSets.php
+++ b/lib/hz2600/Kazoo/Api/Collection/TemporalRulesSets.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Kazoo\Api\Collection;
+
+class TemporalRulesSets extends AbstractCollection
+{
+}
+
+

--- a/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
+++ b/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
@@ -177,19 +177,27 @@ abstract class AbstractEntity extends AbstractResource
      * id then it will be created.
      *
      */
-    public function save($append_uri = null) {
+    public function save($append_uri = null, $method = "post") {
         if ($this->read_only) {
             throw new ReadOnly("The entity is read-only");
         }
 
         $id = $this->getId();
-        $payload = $this->getPayload();
+
+        if ($method == "post") {
+            $payload = $this->getPayload();
+        } else {
+            $shell = new stdClass();
+            $shell->data = $this->entity;
+            $payload = json_encode($shell);
+        }
+
         $this->setTokenValue($this->getEntityIdName(), $id);
 
         if (empty($id)) {
             $response = $this->put($payload, $append_uri);
         } else {
-            $response = $this->post($payload, $append_uri);
+            $response = $this->$method($payload, $append_uri);
         }
 
         $entity = $response->getData();

--- a/lib/hz2600/Kazoo/Api/Entity/Blacklist.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Blacklist.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class Blacklist extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.

--- a/lib/hz2600/Kazoo/Api/Entity/Clicktocall.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Clicktocall.php
@@ -1,0 +1,18 @@
+<?php
+namespace Kazoo\Api\Entity;
+
+use \Kazoo\Common\Exception\ReadOnly;
+use \Kazoo\Common\ChainableInterface;
+
+class Clicktocall extends AbstractEntity
+{
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *
+     */
+    public function save($append_uri = null) {
+        return parent::save($append_uri,"patch");
+    }
+
+}

--- a/lib/hz2600/Kazoo/Api/Entity/Config.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Config.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kazoo\Api\Entity;
+
+class Config extends AbstractEntity
+{
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *
+     */
+    public function save($append_uri = null) {
+        return parent::save($append_uri,"patch");
+    }
+
+    /**
+     * Automagic used to determine the URL snippet.
+     * This should be implemented in the entity class if
+     * it is an exception to the standard naming.
+     *
+     */
+    protected function getUriSnippet() {
+        $collectionName = $this->getCollectionName();
+        $entityId = $this->getId();
+        
+        if (isset($entityId)) {
+            $entityId = str_replace("configs_","",$entityId);
+            return "/$collectionName/$entityId";
+        } else {
+            $entityIdName = $this->getEntityIdName();
+        }
+        return "/$collectionName/{{$entityIdName}";
+    }
+
+
+}    

--- a/lib/hz2600/Kazoo/Api/Entity/Directory.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Directory.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class Directory extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.

--- a/lib/hz2600/Kazoo/Api/Entity/Fax.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Fax.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kazoo\Api\Entity;
+
+class Fax extends AbstractEntity
+{
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *
+     */
+    public function save($append_uri = null) {
+        return parent::save($append_uri,"patch");
+    }
+
+    protected function getUriSnippet() {
+        return "/faxes/outgoing/".$this->getId();
+    }
+}
+ 

--- a/lib/hz2600/Kazoo/Api/Entity/Group.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Group.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class Group extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.

--- a/lib/hz2600/Kazoo/Api/Entity/Queue.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Queue.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kazoo\Api\Entity;
+
+
+class Queue extends AbstractEntity
+{
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *                                                                                                                                                                                                                                  
+     */                                                                                                                                                                                                                                 
+    public function save($append_uri = null) {                                                                                                                                                                                          
+        return parent::save($append_uri,"patch");                                                                                                                                                                                       
+    }
+}    

--- a/lib/hz2600/Kazoo/Api/Entity/Rate.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Rate.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class Rate extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.
@@ -17,4 +13,5 @@ class Connectivity extends AbstractEntity
         return parent::save($append_uri,"patch");
     }
 
-}    
+}
+ 

--- a/lib/hz2600/Kazoo/Api/Entity/ResourceTemplate.php
+++ b/lib/hz2600/Kazoo/Api/Entity/ResourceTemplate.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kazoo\Api\Entity;
+
+class ResourceTemplate extends AbstractEntity
+{
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *
+     */
+    public function save($append_uri = null) {
+        return parent::save($append_uri,"patch");
+    }
+
+    protected function getUriSnippet() {
+        return "/resource/resource_templates/".$this->getId();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Api/Entity/TemporalRule.php
+++ b/lib/hz2600/Kazoo/Api/Entity/TemporalRule.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class TemporalRule extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.

--- a/lib/hz2600/Kazoo/Api/Entity/TemporalRulesSet.php
+++ b/lib/hz2600/Kazoo/Api/Entity/TemporalRulesSet.php
@@ -2,12 +2,8 @@
 
 namespace Kazoo\Api\Entity;
 
-class Connectivity extends AbstractEntity
+class TemporalRulesSet extends AbstractEntity
 {
-    protected function getCollectionName(){
-        return "connectivity";
-    }
-
     /**
      * Saves the current entity, if it does not have an
      * id then it will be created.

--- a/lib/hz2600/Kazoo/Api/Entity/User.php
+++ b/lib/hz2600/Kazoo/Api/Entity/User.php
@@ -20,4 +20,13 @@ class User extends AbstractEntity
         $this->setTokenValue('quickcall_number', $number);
         $this->get(array(), $url);
     }
+
+    /**
+     * Saves the current entity, if it does not have an
+     * id then it will be created.
+     *
+     */
+    public function save($append_uri = null) {
+        return parent::save($append_uri,"patch");
+    }
 }

--- a/lib/hz2600/Kazoo/Common/Utils.php
+++ b/lib/hz2600/Kazoo/Common/Utils.php
@@ -61,6 +61,10 @@ class Utils
      *   https://stackoverflow.com/questions/1534127/pluralize-in-php
      */
     public static function pluralize($word) {
+        if ($word == "clicktocall") {
+            return $word;
+        }
+
         switch(strtolower($word[strlen($word) - 1])) {
         case 'y':
             return substr($word, 0, -1) . 'ies';

--- a/lib/hz2600/Kazoo/Tests/Common/FunctionalTest.php
+++ b/lib/hz2600/Kazoo/Tests/Common/FunctionalTest.php
@@ -42,4 +42,8 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     public function getSDK() {
         return $this->sdk;
     }
+
+    public function testVerify() {
+        $this->assertTrue(TRUE);
+    }
 }

--- a/lib/hz2600/Kazoo/Tests/Functional/BlacklistsTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/BlacklistsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class BlacklistTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateBlacklist() {
+        $blacklist = $this->getSDK()->Account()->Blacklist();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Blacklist", $blacklist);
+        $this->assertTrue((strlen($blacklist->getId()) == 0));
+
+        $blacklist->name = "SDK Create Test " . rand(100, 1000);
+        $blacklist->save();
+
+        $this->assertTrue((strlen($blacklist->getId()) > 0));
+        return $blacklist->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateBlacklist
+     */
+    public function testFetchBlacklist($blacklist_id) {
+        $blacklist = $this->getSDK()->Account()->Blacklist($blacklist_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Blacklist", $blacklist);
+        $this->assertTrue((strlen($blacklist->getId()) > 0));
+        $this->assertEquals($blacklist->getId(), $blacklist_id);
+
+        return $blacklist;
+    }
+
+    /**
+     * @test
+     * @depends testFetchBlacklist
+     */
+    public function testUpdateBlacklist($blacklist) {
+        $blacklist_id = $blacklist->getId();
+        $current_name = $blacklist->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $blacklist->name = $new_name;
+        $blacklist->save();
+
+        // Make sure we didn't create a new blacklist
+        $this->assertEquals($blacklist->getId(), $blacklist_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($blacklist->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $blacklist->fetch();
+        $this->assertEquals($blacklist->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateBlacklist
+     */
+    public function testListingBlacklists($blacklist_id) {
+        $blacklists = $this->getSDK()->Account()->Blacklists();
+
+        $blacklist = null;
+        foreach($blacklists as $element) {
+            if ($element->id == $blacklist_id) {
+                $blacklist = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Blacklist", $blacklist);
+        $this->assertTrue((strlen($blacklist->getId()) > 0));
+        $this->assertEquals($blacklist->getId(), $blacklist_id);
+
+        return $blacklist->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateBlacklist
+     * @depends testListingBlacklists
+     */
+    public function testFilteredListingBlacklists($blacklist_id, $blacklist_name) {
+        $filter = array('filter_name' => $blacklist_name);
+        $blacklists = $this->getSDK()->Account()->Blacklists($filter);
+
+        $this->assertTrue(count($blacklists) == 1);
+
+        $element = $blacklists->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $blacklist_id);
+
+        $filter = array('filter_name' => 'no-such-blacklist');
+        $blacklists = $this->getSDK()->Account()->blacklists($filter);
+
+        $this->assertTrue(count($blacklists) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchBlacklist
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildBlacklist($blacklist) {
+        $blacklist_id = $blacklist->getId();
+
+        $this->assertTrue((strlen($blacklist->getId()) > 0));
+
+        $blacklist->remove();
+
+        $this->assertTrue((strlen($blacklist->getId()) == 0));
+
+//        $blacklist($blacklist_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/ClicktocallsTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/ClicktocallsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class ClicktocallTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateClicktocall() {
+        $clicktocall = $this->getSDK()->Account()->Clicktocall();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Clicktocall", $clicktocall);
+        $this->assertTrue((strlen($clicktocall->getId()) == 0));
+
+        $clicktocall->name = "SDK Create Test " . rand(100, 1000);
+        $clicktocall->extension= "15342";
+        $clicktocall->save();
+
+        $this->assertTrue((strlen($clicktocall->getId()) > 0));
+        return $clicktocall->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateClicktocall
+     */
+    public function testFetchClicktocall($clicktocall_id) {
+        $clicktocall = $this->getSDK()->Account()->Clicktocall($clicktocall_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Clicktocall", $clicktocall);
+        $this->assertTrue((strlen($clicktocall->getId()) > 0));
+        $this->assertEquals($clicktocall->getId(), $clicktocall_id);
+
+        return $clicktocall;
+    }
+
+    /**
+     * @test
+     * @depends testFetchClicktocall
+     */
+    public function testUpdateClicktocall($clicktocall) {
+        $clicktocall_id = $clicktocall->getId();
+        $current_name = $clicktocall->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $clicktocall->name = $new_name;
+        $clicktocall->save();
+
+        // Make sure we didn't create a new clicktocall
+        $this->assertEquals($clicktocall->getId(), $clicktocall_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($clicktocall->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $clicktocall->fetch();
+        $this->assertEquals($clicktocall->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateClicktocall
+     */
+    public function testListingClicktocalls($clicktocall_id) {
+        $clicktocalls = $this->getSDK()->Account()->Clicktocalls();
+
+        $clicktocall = null;
+        foreach($clicktocalls as $element) {
+            if ($element->id == $clicktocall_id) {
+                $clicktocall = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Clicktocall", $clicktocall);
+        $this->assertTrue((strlen($clicktocall->getId()) > 0));
+        $this->assertEquals($clicktocall->getId(), $clicktocall_id);
+
+        return $clicktocall->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateClicktocall
+     * @depends testListingClicktocalls
+     */
+    public function testFilteredListingClicktocalls($clicktocall_id, $clicktocall_name) {
+        $filter = array('filter_name' => $clicktocall_name);
+        $clicktocalls = $this->getSDK()->Account()->Clicktocalls($filter);
+
+        $this->assertTrue(count($clicktocalls) == 1);
+
+        $element = $clicktocalls->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $clicktocall_id);
+
+        $filter = array('filter_name' => 'no-such-clicktocall');
+        $clicktocalls = $this->getSDK()->Account()->clicktocalls($filter);
+
+        $this->assertTrue(count($clicktocalls) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchClicktocall
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildClicktocall($clicktocall) {
+        $clicktocall_id = $clicktocall->getId();
+
+        $this->assertTrue((strlen($clicktocall->getId()) > 0));
+
+        $clicktocall->remove();
+
+        $this->assertTrue((strlen($clicktocall->getId()) == 0));
+
+//        $clicktocall($clicktocall_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/ConfigsTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/ConfigsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class ConfigTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateConfig() {
+        $config = $this->getSDK()->Account()->Config();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Config", $config);
+        $this->assertTrue((strlen($config->getId()) == 0));
+
+        $config->name = "SDK Create Test " . rand(100, 1000);
+        $id_name = "entity".rand(10,99);
+        $config->save($id_name);
+
+        $this->assertTrue((strlen($config->getId()) > 0));
+        return $config->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateConfig
+     */
+    public function testFetchConfig($config_id) {
+        $config = $this->getSDK()->Account()->Config($config_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Config", $config);
+        $this->assertTrue((strlen($config->getId()) > 0));
+        $this->assertEquals($config->getId(), $config_id);
+
+        return $config;
+    }
+
+    /**
+     * @test
+     * @depends testFetchConfig
+     */
+    public function testUpdateConfig($config) {
+        $config_id = $config->getId();
+        
+        $current_name = $config->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $config->name = $new_name;
+        $config->save();
+
+        // Make sure we didn't create a new config
+        $this->assertEquals($config->getId(), $config_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($config->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $config->fetch();
+        $this->assertEquals($config->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testFetchConfig
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildConfig($config) {
+        $config_id = $config->getId();
+        $this->assertTrue((strlen($config->getId()) > 0));
+
+        $config->remove();
+
+        $this->assertTrue((strlen($config->getId()) == 0));
+
+        //$config($config_id)->fetch();
+    } 
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/FaxesTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/FaxesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class FaxesTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateFax() {
+        $fax = $this->getSDK()->Account()->Fax();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Fax", $fax);
+        $this->assertTrue((strlen($fax->getId()) == 0));
+
+        $fax->from_name = "SDK Create Test " . rand(100, 1000);
+        $fax->save();
+
+        $this->assertTrue((strlen($fax->getId()) > 0));
+        return $fax->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateFax
+     */
+    public function testFetchFax($fax_id) {
+        $fax = $this->getSDK()->Account()->Fax($fax_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Fax", $fax);
+        $this->assertTrue((strlen($fax->getId()) > 0));
+        $this->assertEquals($fax->getId(), $fax_id);
+
+        return $fax;
+    }
+
+    /**
+     * @test
+     * @depends testFetchFax
+     */
+    public function testUpdateFax($fax) {
+        $fax_id = $fax->getId();
+        $current_name = $fax->from_name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $fax->from_name = $new_name;
+        $fax->save();
+
+        // Make sure we didn't create a new fax
+        $this->assertEquals($fax->getId(), $fax_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($fax->from_name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $fax->fetch();
+        $this->assertEquals($fax->from_name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateFax
+     */
+    public function testListingFaxes($fax_id) {
+        $faxes = $this->getSDK()->Account()->Faxes();
+
+        $fax = null;
+        foreach($faxes as $element) {
+            if ($element->id == $fax_id) {
+                $fax = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Fax", $fax);
+        $this->assertTrue((strlen($fax->getId()) > 0));
+        $this->assertEquals($fax->getId(), $fax_id);
+
+        return $fax->from_name;
+    }
+
+
+    /**
+     * @test
+     * @depends testCreateFax
+     * @depends testListingFaxes
+     */
+    public function testFilteredListingFaxes($fax_id) {
+        $filter = array('filter_id' => $fax_id);
+        $faxes = $this->getSDK()->Account()->Faxes($filter);
+
+        $this->assertTrue(count($faxes) == 1);
+
+        $element = $faxes->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $fax_id);
+
+        $filter = array('filter_id' => 'no-such-faxes');
+        $faxes = $this->getSDK()->Account()->Faxes($filter);
+
+        $this->assertTrue(count($faxes) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchFax
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildFaxes($fax) {
+        $fax_id = $fax->getId();
+
+        $this->assertTrue((strlen($fax->getId()) > 0));
+
+        $fax->remove();
+
+        $this->assertTrue((strlen($fax->getId()) == 0));
+
+//        $faxes($fax_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/GroupsTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/GroupsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+use \stdClass;
+/**
+ * @group functional
+ */
+class GroupTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateGroup() {
+        $group = $this->getSDK()->Account()->Group();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Group", $group);
+        $this->assertTrue((strlen($group->getId()) == 0));
+
+        $group->name = "SDK Create Test " . rand(100, 1000);
+        $group->endpoints = new stdClass;
+        $group->save();
+
+        $this->assertTrue((strlen($group->getId()) > 0));
+        return $group->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateGroup
+     */
+    public function testFetchGroup($group_id) {
+        $group = $this->getSDK()->Account()->Group($group_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Group", $group);
+        $this->assertTrue((strlen($group->getId()) > 0));
+        $this->assertEquals($group->getId(), $group_id);
+
+        return $group;
+    }
+
+    /**
+     * @test
+     * @depends testFetchGroup
+     */
+    public function testUpdateGroup($group) {
+        $group_id = $group->getId();
+        $current_name = $group->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $group->name = $new_name;
+        $group->save();
+
+        // Make sure we didn't create a new group
+        $this->assertEquals($group->getId(), $group_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($group->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $group->fetch();
+        $this->assertEquals($group->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateGroup
+     */
+    public function testListingGroups($group_id) {
+        $groups = $this->getSDK()->Account()->Groups();
+        
+        $group = null;
+        foreach($groups as $element) {
+            if ($element->id == $group_id) {
+                $group = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Group", $group);
+        $this->assertTrue((strlen($group->getId()) > 0));
+        $this->assertEquals($group->getId(), $group_id);
+
+        return $group->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateGroup
+     * @depends testListingGroups
+     */
+    public function testFilteredListingGroups($group_id, $group_name) {
+        $filter = array('filter_name' => $group_name);
+        $groups = $this->getSDK()->Account()->Groups($filter);
+
+        $this->assertTrue(count($groups) == 1);
+
+        $element = $groups->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $group_id);
+
+        $filter = array('filter_name' => 'no-such-group');
+        $groups = $this->getSDK()->Account()->groups($filter);
+
+        $this->assertTrue(count($groups) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchGroup
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildGroup($group) {
+        $group_id = $group->getId();
+
+        $this->assertTrue((strlen($group->getId()) > 0));
+
+        $group->remove();
+
+        $this->assertTrue((strlen($group->getId()) == 0));
+
+//        $group($group_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/QueuesTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/QueuesTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class QueueTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateQueue() {
+        $queue = $this->getSDK()->Account()->Queue();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Queue", $queue);
+        $this->assertTrue((strlen($queue->getId()) == 0));
+
+        $queue->name = "SDK Create Test " . rand(100, 1000);
+        $queue->save();
+
+        $this->assertTrue((strlen($queue->getId()) > 0));
+        return $queue->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateQueue
+     */
+    public function testFetchQueue($queue_id) {
+        $queue = $this->getSDK()->Account()->Queue($queue_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Queue", $queue);
+        $this->assertTrue((strlen($queue->getId()) > 0));
+        $this->assertEquals($queue->getId(), $queue_id);
+
+        return $queue;
+    }
+
+    /**
+     * @test
+     * @depends testFetchQueue
+     */
+    public function testUpdateQueue($queue) {
+        $queue_id = $queue->getId();
+        $current_name = $queue->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $queue->name = $new_name;
+        $queue->save();
+
+        // Make sure we didn't create a new queue
+        $this->assertEquals($queue->getId(), $queue_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($queue->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $queue->fetch();
+        $this->assertEquals($queue->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateQueue
+     */
+    public function testListingQueues($queue_id) {
+        $queues = $this->getSDK()->Account()->Queues();
+
+        $queue = null;
+        foreach($queues as $element) {
+            if ($element->id == $queue_id) {
+                $queue = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Queue", $queue);
+        $this->assertTrue((strlen($queue->getId()) > 0));
+        $this->assertEquals($queue->getId(), $queue_id);
+
+        return $queue->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateQueue
+     * @depends testListingQueues
+     */
+    public function testFilteredListingQueues($queue_id, $queue_name) {
+        $filter = array('filter_name' => $queue_name);
+        $queues = $this->getSDK()->Account()->Queues($filter);
+
+        $this->assertTrue(count($queues) == 1);
+
+        $element = $queues->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $queue_id);
+
+        $filter = array('filter_name' => 'no-such-queue');
+        $queues = $this->getSDK()->Account()->Queues($filter);
+
+        $this->assertTrue(count($queues) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchQueue
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildQueue($queue) {
+        $queue_id = $queue->getId();
+
+        $this->assertTrue((strlen($queue->getId()) > 0));
+
+        $queue->remove();
+
+        $this->assertTrue((strlen($queue->getId()) == 0));
+
+//        $queue($queue_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/RatesTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/RatesTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+
+/**
+ * @rate functional
+ */
+class RateTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateRate() {
+        $rate = $this->getSDK()->Account()->Rate();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Rate", $rate);
+        $this->assertTrue((strlen($rate->getId()) == 0));
+
+        $rate->prefix = rand(100,999);
+        $rate->rate_cost = 1;
+        $rate->save();
+
+        $this->assertTrue((strlen($rate->getId()) > 0));
+        return $rate->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateRate
+     */
+    public function testFetchRate($rate_id) {
+        $rate = $this->getSDK()->Account()->Rate($rate_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Rate", $rate);
+        $this->assertTrue((strlen($rate->getId()) > 0));
+        $this->assertEquals($rate->getId(), $rate_id);
+
+        return $rate;
+    }
+
+    /**
+     * @test
+     * @depends testFetchRate
+     */
+    public function testUpdateRate($rate) {
+        $rate_id = $rate->getId();
+        $current_prefix = $rate->prefix;
+        $new_prefix = rand(100,999);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_prefix, $new_prefix);
+
+        $rate->prefix = $new_prefix;
+        $rate->save();
+
+        // Make sure we didn't create a new rate
+        $this->assertEquals($rate->getId(), $rate_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($rate->prefix, $new_prefix);
+
+        // Fetch it from the database again to make sure
+        $rate->fetch();
+        $this->assertEquals($rate->prefix, $new_prefix);
+    }
+
+    /**
+     * @test
+     * @depends testCreateRate
+     */
+    public function testListingRates($rate_id) {
+        $this->markTestSkipped('Until Fix https://2600hz.atlassian.net/browse/KAZOO-3939');
+        $rates = $this->getSDK()->Account()->Rates();
+        $rate = null;
+        foreach($rates as $element) {
+            $myel = $element->fetch();
+            if ($element->id == $rate_id) {
+                $rate = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\Rate", $rate);
+        $this->assertTrue((strlen($rate->getId()) > 0));
+        $this->assertEquals($rate->getId(), $rate_id);
+
+        return $rate->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateRate
+     * @depends testListingRates
+     */
+    public function testFilteredListingRates($rate_id, $rate_prefix) {
+        $filter = array('filter_prefix' => $rate_prefix);
+        $rates = $this->getSDK()->Account()->Rates($filter);
+
+        $this->assertTrue(count($rates) == 1);
+
+        $element = $rates->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $rate_id);
+
+        $filter = array('filter_prefix' => 'no-such-rate');
+        $rates = $this->getSDK()->Account()->rates($filter);
+
+        $this->assertTrue(count($rates) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchRate
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildRate($rate) {
+        $rate_id = $rate->getId();
+
+        $this->assertTrue((strlen($rate->getId()) > 0));
+
+        $rate->remove();
+
+        $this->assertTrue((strlen($rate->getId()) == 0));
+
+//        $rate($rate_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/ResourceTemplateTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/ResourceTemplateTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class ResourceTemplateTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateResourceTemplate() {
+        $resourcetemplate = $this->getSDK()->Account()->ResourceTemplate();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\ResourceTemplate", $resourcetemplate);
+        $this->assertTrue((strlen($resourcetemplate->getId()) == 0));
+
+        $resourcetemplate->template_name = "SDK Create Test ";
+        $resourcetemplate->save();
+
+        $this->assertTrue((strlen($resourcetemplate->getId()) > 0));
+        return $resourcetemplate->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateResourceTemplate
+     */
+    public function testFetchResourceTemplate($resourcetemplate_id) {
+        $resourcetemplate = $this->getSDK()->Account()->ResourceTemplate($resourcetemplate_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\ResourceTemplate", $resourcetemplate);
+        $this->assertTrue((strlen($resourcetemplate->getId()) > 0));
+        $this->assertEquals($resourcetemplate->getId(), $resourcetemplate_id);
+
+        return $resourcetemplate;
+    }
+
+    /**
+     * @test
+     * @depends testFetchResourceTemplate
+     */
+    public function testUpdateResourceTemplate($resourcetemplate) {
+        $resourcetemplate_id = $resourcetemplate->getId();
+        $current_name = $resourcetemplate->template_name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $resourcetemplate->template_name = $new_name;
+        $resourcetemplate->save();
+
+        // Make sure we didn't create a new resourcetemplate
+        $this->assertEquals($resourcetemplate->getId(), $resourcetemplate_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($resourcetemplate->template_name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $resourcetemplate->fetch();
+        $this->assertEquals($resourcetemplate->template_name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateResourceTemplate
+     * @depends testUpdateResourceTemplate
+     */
+    public function testListingResourceTemplates($resourcetemplate_id) {
+        $resourcetemplates = $this->getSDK()->Account()->ResourceTemplates();
+
+        $resourcetemplate = null;
+        foreach($resourcetemplates as $element) {
+            if ($element->id == $resourcetemplate_id) {
+                $resourcetemplate = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\ResourceTemplate", $resourcetemplate);
+        $this->assertTrue((strlen($resourcetemplate->getId()) > 0));
+        $this->assertEquals($resourcetemplate->getId(), $resourcetemplate_id);
+
+        return $resourcetemplate->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateResourceTemplate
+     * @depends testListingResourceTemplates
+     */
+    public function testFilteredListingResourceTemplates($resourcetemplate_id) {
+        $filter = array('filter_id' => $resourcetemplate_id);
+        $resourcetemplates = $this->getSDK()->Account()->ResourceTemplates($filter);
+
+        $this->assertTrue(count($resourcetemplates) == 1);
+
+        $element = $resourcetemplates->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $resourcetemplate_id);
+
+        $filter = array('filter_id' => 'no-such-id');
+        $resourcetemplates = $this->getSDK()->Account()->ResourceTemplates($filter);
+
+        $this->assertTrue(count($resourcetemplates) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchResourceTemplate
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildResourceTemplate($resourcetemplate) {
+        $resourcetemplate_id = $resourcetemplate->getId();
+
+        $this->assertTrue((strlen($resourcetemplate->getId()) > 0));
+
+        $resourcetemplate->remove();
+
+        $this->assertTrue((strlen($resourcetemplate->getId()) == 0));
+
+//        $resourcetemplate($resourcetemplatewq_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/TemporalRulesSetsTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/TemporalRulesSetsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class TemporalRulesSetTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateTemporalRulesSet() {
+        $temporalrulesset = $this->getSDK()->Account()->TemporalRulesSet();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRulesSet", $temporalrulesset);
+        $this->assertTrue((strlen($temporalrulesset->getId()) == 0));
+
+        $temporalrulesset->name = "SDK Create Test " . rand(100, 1000);
+        $temporalrulesset->save();
+
+        $this->assertTrue((strlen($temporalrulesset->getId()) > 0));
+        return $temporalrulesset->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRulesSet
+     */
+    public function testFetchTemporalRulesSet($temporalrulesset_id) {
+        $temporalrulesset = $this->getSDK()->Account()->TemporalRulesSet($temporalrulesset_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRulesSet", $temporalrulesset);
+        $this->assertTrue((strlen($temporalrulesset->getId()) > 0));
+        $this->assertEquals($temporalrulesset->getId(), $temporalrulesset_id);
+
+        return $temporalrulesset;
+    }
+
+    /**
+     * @test
+     * @depends testFetchTemporalRulesSet
+     */
+    public function testUpdateTemporalRulesSet($temporalrulesset) {
+        $temporalrulesset_id = $temporalrulesset->getId();
+        $current_name = $temporalrulesset->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $temporalrulesset->name = $new_name;
+        $temporalrulesset->save();
+
+        // Make sure we didn't create a new temporalrulesset
+        $this->assertEquals($temporalrulesset->getId(), $temporalrulesset_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($temporalrulesset->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $temporalrulesset->fetch();
+        $this->assertEquals($temporalrulesset->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRulesSet
+     */
+    public function testListingTemporalRulesSets($temporalrulesset_id) {
+        $temporalrulessets = $this->getSDK()->Account()->TemporalRulesSets();
+
+        $temporalrulesset = null;
+        foreach($temporalrulessets as $element) {
+            if ($element->id == $temporalrulesset_id) {
+                $temporalrulesset = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRulesSet", $temporalrulesset);
+        $this->assertTrue((strlen($temporalrulesset->getId()) > 0));
+        $this->assertEquals($temporalrulesset->getId(), $temporalrulesset_id);
+
+        return $temporalrulesset->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRulesSet
+     * @depends testListingTemporalRulesSets
+     */
+    public function testFilteredListingTemporalRulesSets($temporalrulesset_id, $temporalrulesset_name) {
+        $filter = array('filter_name' => $temporalrulesset_name);
+        $temporalrulessets = $this->getSDK()->Account()->TemporalRulesSets($filter);
+
+        $this->assertTrue(count($temporalrulessets) == 1);
+
+        $element = $temporalrulessets->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $temporalrulesset_id);
+
+        $filter = array('filter_name' => 'no-such-temporalrulesset');
+        $temporalrulessets = $this->getSDK()->Account()->TemporalRulesSets($filter);
+
+        $this->assertTrue(count($temporalrulessets) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchTemporalRulesSet
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildTemporalRulesSet($temporalrulesset) {
+        $temporalrulesset_id = $temporalrulesset->getId();
+
+        $this->assertTrue((strlen($temporalrulesset->getId()) > 0));
+
+        $temporalrulesset->remove();
+
+        $this->assertTrue((strlen($temporalrulesset->getId()) == 0));
+
+//        $temporalrulesset($temporalrulesset_id)->fetch();
+    }
+
+}

--- a/lib/hz2600/Kazoo/Tests/Functional/TemporalRulesTest.php
+++ b/lib/hz2600/Kazoo/Tests/Functional/TemporalRulesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Kazoo\Tests\Functional;
+
+use \Kazoo\Tests\Common\FunctionalTest;
+
+/**
+ * @group functional
+ */
+class TemporalRulesTest extends FunctionalTest
+{
+    /**
+     * @test
+     */
+    public function testCreateTemporalRule() {
+        $temporalrule = $this->getSDK()->Account()->TemporalRule();
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRule", $temporalrule);
+        $this->assertTrue((strlen($temporalrule->getId()) == 0));
+
+        $temporalrule->name = "SDK Create Test " . rand(100, 1000);
+        $temporalrule->cycle="weekly";
+        $temporalrule->save();
+
+        $this->assertTrue((strlen($temporalrule->getId()) > 0));
+        return $temporalrule->getId();
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRule
+     */
+    public function testFetchTemporalRule($temporalrule_id) {
+        $temporalrule = $this->getSDK()->Account()->TemporalRule($temporalrule_id);
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRule", $temporalrule);
+        $this->assertTrue((strlen($temporalrule->getId()) > 0));
+        $this->assertEquals($temporalrule->getId(), $temporalrule_id);
+
+        return $temporalrule;
+    }
+
+    /**
+     * @test
+     * @depends testFetchTemporalRule
+     */
+    public function testUpdateTemporalRule($temporalrule) {
+        $temporalrule_id = $temporalrule->getId();
+        $current_name = $temporalrule->name;
+        $new_name = "SDK Update Test " . rand(100, 1000);
+
+        // Ensure our test actually update the name...
+        $this->assertNotEquals($current_name, $new_name);
+
+        $temporalrule->name = $new_name;
+        $temporalrule->save();
+
+        // Make sure we didn't create a new temporalrule
+        $this->assertEquals($temporalrule->getId(), $temporalrule_id);
+
+        // The local copy is updated with the result of the
+        // API request
+        $this->assertEquals($temporalrule->name, $new_name);
+
+        // Fetch it from the database again to make sure
+        $temporalrule->fetch();
+        $this->assertEquals($temporalrule->name, $new_name);
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRule
+     */
+    public function testListingTemporalRules($temporalrule_id) {
+        $temporalrules = $this->getSDK()->Account()->TemporalRules();
+
+        $temporalrule = null;
+        foreach($temporalrules as $element) {
+            if ($element->id == $temporalrule_id) {
+                $temporalrule = $element->fetch();
+                break;
+            }
+        }
+
+        $this->assertInstanceOf("\\Kazoo\\Api\\Entity\\TemporalRule", $temporalrule);
+        $this->assertTrue((strlen($temporalrule->getId()) > 0));
+        $this->assertEquals($temporalrule->getId(), $temporalrule_id);
+
+        return $temporalrule->name;
+    }
+
+    /**
+     * @test
+     * @depends testCreateTemporalRule
+     * @depends testListingTemporalRules
+     */
+    public function testFilteredListingTemporalRules($temporalrule_id, $temporalrule_name) {
+        $filter = array('filter_name' => $temporalrule_name);
+        $temporalrules = $this->getSDK()->Account()->TemporalRules($filter);
+
+        $this->assertTrue(count($temporalrules) == 1);
+
+        $element = $temporalrules->current();
+
+        $this->assertTrue((strlen($element->id) > 0));
+        $this->assertEquals($element->id, $temporalrule_id);
+
+        $filter = array('filter_name' => 'no-such-temporalrules');
+        $temporalrules = $this->getSDK()->Account()->TemporalRules($filter);
+
+        $this->assertTrue(count($temporalrules) == 0);
+    }
+
+    /**
+     * @test
+     * @depends testFetchTemporalRules
+     * @expectedExceptionDisabled \Kazoo\HttpClient\Exception\NotFound
+     */
+    public function testRemoveChildTemporalRules($temporalrule) {
+        $temporalrules_id = $temporalrule->getId();
+
+        $this->assertTrue((strlen($temporalrule->getId()) > 0));
+
+        $temporalrules->remove();
+
+        $this->assertTrue((strlen($temporalrule->getId()) == 0));
+
+//        $temporalrules($temporalrule_id)->fetch();
+    }
+
+}


### PR DESCRIPTION
Add Groups, Blacklists, Directories, Queues, TemporalRules, TemporalRulesSets, Rates, Configs, Users, Faxes, ResourceTemplates  support (with PathMetohd)
Update Connectivity use PATH insted of Post
Add tests for Groups, Blacklists, Directories, Queues, TemporalRules, TemporalRulesSets, Rates, Configs, Users, Faxes, ResourceTemplates
Add simple test in FunctionalTest.php for remove phpunit error
Add KAZOO-3938, KAZOO-3939