### PR TITLE
Updated monolog version to prevent conflict with Symfony2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.2",
         "ext-curl": "*",
         "guzzle/guzzle": "3.9.*@dev",
+        "monolog/monolog": "~1.17"
     },
     "minimum-stability": "stable",
     "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",
-        "guzzle/guzzle": "3.9.*@dev",
-        "monolog/monolog": "1.7.0"
+        "guzzle/guzzle": "3.9.*@dev"
     },
     "minimum-stability": "stable",
     "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",
-        "guzzle/guzzle": "3.9.*@dev"
+        "guzzle/guzzle": "3.9.*@dev",
     },
     "minimum-stability": "stable",
     "preferred-install": "dist",


### PR DESCRIPTION
Updated monolog version to be able to use the library within a Symfony2 project.