### PR TITLE
Allow creating accounts as children of other accounts

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Account.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Account.php
@@ -57,4 +57,26 @@ class Account extends AbstractEntity
     public function move() {
 
     }
+
+    /**
+     * Create a child account of this account. Returns the new Account entity.
+     *
+     * @param \Kazoo\Api\Entity\Account $account The account to create below
+     * this account
+     *
+     * @return \Kazoo\Api\Entity\Account The new child account after saving
+     */
+    public function createChild($account) {
+        $id = $this->getId();
+        $payload = $account->getPayload();
+
+        $this->setTokenValue($this->getEntityIdName(), $id);
+
+        $response = $this->put($payload);
+
+        $entity = $response->getData();
+        $this->setEntity($entity);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The API for creating child accounts is a bit odd in that it doesn't work like other APIs:
i.e. PUT /accounts/\<parent-account-id>/users $payload
PUT /accounts/\<parent-account-id>/devices $payload
vs
PUT /accounts/\<parent-account-id> $childAccountPayload
instead of
PUT /accounts/\<parent-account-id>/accounts $childAccountPayload

Added createChild function to Account Entity to facilitate this functionality.