### PR TITLE
Update AbstractEntity.php

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
+++ b/lib/hz2600/Kazoo/Api/Entity/AbstractEntity.php
@@ -154,6 +154,26 @@ abstract class AbstractEntity extends AbstractResource
 
         $this->setId();
     }
+    
+     /**
+     * downloads or streams a media file
+     * @param  boolean $stream  Set to true to stream the file
+     * @return binary           Media file
+     */
+    public function getRaw($stream = false)
+    {
+        $this->setTokenValue($this->getEntityIdName(), $this->getId());
+        $uri = $this->getURI('/raw');
+        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'audio/*', 'content_type'=>'audio/*'));
+
+        header('Content-Type: '.$x->getHeader('Content-Type')[0]);
+        header('content-length: '.$x->getHeader('content-length')[0]);
+
+        if (!$stream) {
+            header('Content-Disposition: '.$x->getHeader('Content-Disposition')[0]);
+        }
+        echo $x->getBody();
+    }
 
     /**
      * Explicitly fetch from Kazoo, typicall it lazy-loads.


### PR DESCRIPTION
Remove getRaw() method from Media subclass https://github.com/2600hz/kazoo-php-sdk/pull/117/commits/3ce590ee52694dfd551ba496e52ba94b4ff955f7 and put it in AbstracEntity parent class instead.  This method is used (at least by us) in Message Class for listening to voicemails.  So I think it makes more sense as an inherited method rather than duplicating it.