### PR TITLE
Update Media.php

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Media.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Media.php
@@ -4,28 +4,7 @@ namespace Kazoo\Api\Entity;
 
 class Media extends AbstractEntity
 {
-
-    /**
-     * downloads or streams a media file
-     * @param  boolean $stream  Set to true to stream the file
-     * @return binary           Media file
-     */
-    public function getRaw($stream = false)
-    {
-        $this->setTokenValue($this->getEntityIdName(), $this->getId());
-        $uri = $this->getURI('/raw');
-        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'audio/*', 'content_type'=>'audio/*'));
-
-        header('Content-Type: '.$x->getHeader('Content-Type')[0]);
-        header('content-length: '.$x->getHeader('content-length')[0]);
-
-        if (!$stream) {
-            header('Content-Disposition: '.$x->getHeader('Content-Disposition')[0]);
-        }
-        echo $x->getBody();
-    }
-
-
+    
     /**
      * posts media file
      * @param  string $path      Local path of media file


### PR DESCRIPTION
Move getRaw() to AbstractEntity class in this pull request https://github.com/2600hz/kazoo-php-sdk/pull/116/commits/a1c9c7f1d8678ed88387309540af959c13fd3b99 .  

This method is used (at least by us) in Message Class for listening to voicemails.  So I think it makes more sense in the inherited parent of both classes rather than duplicating.