### PR TITLE
Update Media.php

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Media.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Media.php
@@ -14,10 +14,12 @@ class Media extends AbstractEntity
     {
         $this->setTokenValue($this->getEntityIdName(), $this->getId());
         $uri = $this->getURI('/raw');
-        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'audio/*', 'content_type'=>'audio/*'));
+        $x   = $this->getSDK()->get($uri, array(), array('accept'=>'audio/*',
+            'content_type'=>'audio/*', 'Range'=>'bytes'));
 
         header('Content-Type: '.$x->getHeader('Content-Type')[0]);
         header('content-length: '.$x->getHeader('content-length')[0]);
+        header('Accept-Ranges: '.$x->getHeader('Accept-Ranges')[0]);
 
         if (!$stream) {
             header('Content-Disposition: '.$x->getHeader('Content-Disposition')[0]);


### PR DESCRIPTION
Required in order to seek through streaming sound files (at least on voicemails) on Google Chrome using html5 web audio implementation.

ie.
```html
<audio controls><source src="call_getRaw()_sdk_method" type="audio/mpeg"></audio>
```
#### Where I found the hint
https://stackoverflow.com/questions/9711184/how-can-i-make-chrome-use-the-range-http-header-for-seeking-in-audio

#### Request spec
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range

#### Response spec
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges


Btw, I have another pull request to move this getRaw() method into the parent class because I think that is where it belongs in order to use it for both Media and CDR classes.
https://github.com/2600hz/kazoo-php-sdk/pull/116/commits/a1c9c7f1d8678ed88387309540af959c13fd3b99
