### PR TITLE
Channels bug fixed

### DIFF
--- a/lib/hz2600/Kazoo/Api/Entity/Account.php
+++ b/lib/hz2600/Kazoo/Api/Entity/Account.php
@@ -42,13 +42,6 @@ class Account extends AbstractEntity
         return $accounts->siblings($filter);
     }
 
-    // TODO: channels is a read-only property...
-    public function channels(array $filter = array()) {
-        $accounts = new Accounts($this->getChain());
-        $accounts->setTokenValue('account_id', $this->getId());
-        return $accounts->channels($filter);
-    }
-
     public function apiKey() {
         $response = $this->get(array(), '/api_key');
         return $response->getData()->api_key;


### PR DESCRIPTION
There is no need to create "channels" function inside Account. This will cause the error "Accounts does not have method channels".
Removing it is enough because there is the Channels collection that returns what we need.